### PR TITLE
Create new webhook expose command for autoregistering webhooks.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     }
   ],
   "require": {
+    "beyondcode/expose": "^1.3",
     "illuminate/console": "6 - 8",
     "telegram-bot-sdk/telegram-bot-sdk": "^4.0@dev"
   },

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     }
   ],
   "require": {
-    "beyondcode/expose": "^1.3",
     "illuminate/console": "6 - 8",
     "telegram-bot-sdk/telegram-bot-sdk": "^4.0@dev"
   },
   "require-dev": {
+    "beyondcode/expose": "^1.3",
     "phpunit/phpunit": "^8.5 || ^9.0"
   },
   "suggest": {

--- a/src/Console/Webhook/WebhookExposeCommand.php
+++ b/src/Console/Webhook/WebhookExposeCommand.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Telegram\Bot\Laravel\Console\Webhook;
+
+use Exception;
+use File;
+use Symfony\Component\Process\Process;
+use Telegram\Bot\Bot;
+use Telegram\Bot\Exceptions\TelegramSDKException;
+use Telegram\Bot\Laravel\Console\ConsoleBaseCommand;
+use Throwable;
+
+class WebhookExposeCommand extends ConsoleBaseCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'telegram:webhook:expose';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Expose your webhook online';
+
+    protected string $exposeUrl;
+    protected string $initialBuffer = '';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        try {
+            $this->exposeWebhook($this->bot());
+        } catch (Throwable $e) {
+            $this->error($e->getMessage());
+        }
+    }
+
+    /**
+     * @param Bot $bot
+     *
+     * @throws TelegramSDKException
+     * @throws Exception
+     */
+    protected function exposeWebhook(Bot $bot): void
+    {
+        $this->info("Exposing webhook for [{$bot->config('bot')}] bot!");
+        $this->newLine();
+
+        $process = $this->exposeProcess();
+        $process->start();
+
+        $this->info("Registering with the Expose Server");
+        $process->waitUntil(function ($type, $output) {
+            return $this->detectOnlineUrl($output);
+        });
+
+        $this->registerWebhook($bot);
+
+        //Now we have everything registered. Remove the timeout.
+        $process->setTimeout(0);
+        $process->wait(function ($type, $buffer) {
+            $this->processOutput($type, $buffer);
+        });
+    }
+
+    /**
+     * @throws Exception
+     * @return Process
+     */
+    protected function exposeProcess()
+    {
+        return (new Process(
+            [
+                $this->exposeBinary(),
+                '--quiet',
+                '--no-interaction',
+            ]
+        ))
+            ->setWorkingDirectory(base_path())
+            ->setTimeout(10);
+    }
+
+    /**
+     * @throws Exception
+     * @return string
+     */
+    protected function exposeBinary()
+    {
+        $binary = base_path('vendor/bin/expose');
+
+        if (File::exists($binary)) {
+            return $binary;
+        }
+
+        throw new Exception('Unable to find the Expose binary');
+    }
+
+    protected function detectOnlineUrl($output): bool
+    {
+        $this->initialBuffer .= $output;
+
+        if (preg_match('/---(.*?Expose-URL:\s+(.+))/is', $this->initialBuffer, $matches)) {
+            $this->exposeUrl = trim($matches[2]);
+            $this->info('Your access URLs are:');
+            $this->comment($matches[1]);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param Bot $bot
+     *
+     * @throws TelegramSDKException
+     */
+    protected function registerWebhook(Bot $bot)
+    {
+        $url = "{$this->exposeUrl}/{$bot->getToken()}/{$bot->config('bot')}";
+
+        $this->info("Registering your webhook with Telegram.");
+        if ($bot->setWebhook(compact('url'))) {
+            $this->info("Success: Telegram is now sending updates to:");
+            $this->comment("$url");
+            return;
+        }
+
+        $this->error('Your webhook could not be registered!');
+    }
+
+    protected function processOutput($type, $buffer)
+    {
+        if ($type === Process::ERR) {
+            $this->error($buffer);
+            return;
+        }
+
+        $this->line($buffer);
+    }
+}

--- a/src/Console/Webhook/WebhookRegisterCommand.php
+++ b/src/Console/Webhook/WebhookRegisterCommand.php
@@ -7,21 +7,21 @@ use Telegram\Bot\Bot;
 use Telegram\Bot\Exceptions\TelegramSDKException;
 use Telegram\Bot\Laravel\Console\ConsoleBaseCommand;
 
-class WebhookSetupCommand extends ConsoleBaseCommand
+class WebhookRegisterCommand extends ConsoleBaseCommand
 {
     /**
      * The console command name.
      *
      * @var string
      */
-    protected $name = 'telegram:webhook:setup';
+    protected $name = 'telegram:webhook:register';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Setup webhook with Telegram Bot API';
+    protected $description = 'Register webhook with Telegram Bot API';
 
     /**
      * Execute the console command.
@@ -29,7 +29,7 @@ class WebhookSetupCommand extends ConsoleBaseCommand
     public function handle(): void
     {
         try {
-            $this->setupWebhook($this->bot());
+            $this->registerWebhook($this->bot());
         } catch (\Throwable $e) {
             $this->error($e->getMessage());
         }
@@ -42,9 +42,9 @@ class WebhookSetupCommand extends ConsoleBaseCommand
      *
      * @throws TelegramSDKException
      */
-    protected function setupWebhook(Bot $bot): void
+    protected function registerWebhook(Bot $bot): void
     {
-        $this->comment("Setting webhook for [{$bot->config('bot')}] bot!");
+        $this->comment("Registering webhook for [{$bot->config('bot')}] bot!");
 
         // Bot webhook config.
         $config = $bot->config('webhook', []);
@@ -61,7 +61,7 @@ class WebhookSetupCommand extends ConsoleBaseCommand
             return;
         }
 
-        $this->error('Your webhook could not be set!');
+        $this->error('Your webhook could not be registered!');
     }
 
     protected function webhookUrl(Bot $bot): string

--- a/src/TelegramServiceProvider.php
+++ b/src/TelegramServiceProvider.php
@@ -101,7 +101,8 @@ class TelegramServiceProvider extends ServiceProvider
                 Console\Command\CommandRegisterCommand::class,
                 Console\Webhook\WebhookInfoCommand::class,
                 Console\Webhook\WebhookRemoveCommand::class,
-                Console\Webhook\WebhookSetupCommand::class,
+                Console\Webhook\WebhookRegisterCommand::class,
+                Console\Webhook\WebhookExposeCommand::class,
             ]);
         }
     }

--- a/src/TelegramServiceProvider.php
+++ b/src/TelegramServiceProvider.php
@@ -103,9 +103,10 @@ class TelegramServiceProvider extends ServiceProvider
                 Console\Webhook\WebhookInfoCommand::class,
                 Console\Webhook\WebhookRemoveCommand::class,
                 Console\Webhook\WebhookRegisterCommand::class,
-            ])
+            ]
+        )
             ->unless($this->app->environment('production'), function (Collection $collection) {
-                    return $collection->merge([Console\Webhook\WebhookExposeCommand::class]);
+                return $collection->merge([Console\Webhook\WebhookExposeCommand::class]);
             })
             ->toArray();
 

--- a/src/TelegramServiceProvider.php
+++ b/src/TelegramServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Telegram\Bot\Laravel;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Telegram\Bot\Api;
@@ -94,16 +95,22 @@ class TelegramServiceProvider extends ServiceProvider
      */
     protected function registerCommands(): void
     {
-        if ($this->app->runningInConsole()) {
-            $this->commands([
+        $commands = collect(
+            [
                 Console\Command\CommandListCommand::class,
                 Console\Command\CommandMakeCommand::class,
                 Console\Command\CommandRegisterCommand::class,
                 Console\Webhook\WebhookInfoCommand::class,
                 Console\Webhook\WebhookRemoveCommand::class,
                 Console\Webhook\WebhookRegisterCommand::class,
-                Console\Webhook\WebhookExposeCommand::class,
-            ]);
+            ])
+            ->unless($this->app->environment('production'), function (Collection $collection) {
+                    return $collection->merge([Console\Webhook\WebhookExposeCommand::class]);
+            })
+            ->toArray();
+
+        if ($this->app->runningInConsole()) {
+            $this->commands($commands);
         }
     }
 


### PR DESCRIPTION
So I've think I've found a way to finally allow an almost fully automatic way for a new developer to get a telegram webhook working during their development.

It's always annoyed me how tricky it is to test inbound webhooks when developing and using external programs like ngrok always seem to take ages to get right and configure....plus the difficulty of using it across multiple platforms.

So with the latest release of [Expose from beyondco.de](https://beyondco.de/docs/expose/introduction) I thought having this included in the project would make a huge difference to getting developing quickly.

This PR does the following:

- Uses [Expose](https://beyondco.de/docs/expose/introduction) to create a free secure tunnel to allow telegram servers to connect and send updates to your local dev machine.
- Introduces a new `telegram:webhook:expose` artisan command to automate the entire process.
- Registers the bot webhook with telegram using the provided URL from expose automatically


**Usage**

- Pull in this PR and ensure you run `composer install`
- Assuming you have already registered you expose Token (see issues below), open your terminal and run the artisan command  `php artisan telegram:webhook:expose`
- This script will connect to the expose server and return a secure url. Then will use that URL and register the webhook for the requested bot. No further action is needed.
- Now all updates from telegram to the bot will be receieved by the local development machine.


**Enhanchements**

- Allow customisation of the domain name requested from expose
- Allow customisation of route path etc.


**Issues**

Whilst the service from Expose is completely free to use their server to create a tunnel, there is the following requirement in their docs:
![image](https://user-images.githubusercontent.com/2513663/98367743-0f2b1c00-202e-11eb-9e1b-39f400a91969.png)

This just means that the user MUST get their own token and run the following command ONCE before using our `telegram:webhook:expose` command:

`expose token [YOUR-AUTH-TOKEN]`


If the user does not do this the expose server will not let them connect.