### PR TITLE
Set command name when resolving

### DIFF
--- a/src/Console/Command/CommandRegisterCommand.php
+++ b/src/Console/Command/CommandRegisterCommand.php
@@ -53,7 +53,7 @@ class CommandRegisterCommand extends ConsoleBaseCommand
         $botCommands = $handler->getCommands();
 
         $commands = collect($botCommands)->map(static function ($command, $name) use ($handler): BotCommand {
-            $command = $handler->getCommandBus()->resolveCommand($command);
+            $command = $handler->getCommandBus()->resolveCommand($command)->setName($name);
 
             return BotCommand::make([
                 // Can contain only lowercase English letters, digits and underscores.


### PR DESCRIPTION
When a command is created the description is already a property of the command class. As a command can have many names (alias) it is not set in the command class itself.

However sometimes there can be logic INSIDE the command class than depends on the name of the command at runtime. This fix allows the command name to be set when it is resolved so that internal logic can use that name.